### PR TITLE
Allow override system prompt

### DIFF
--- a/vibecoder/agents/__init__.py
+++ b/vibecoder/agents/__init__.py
@@ -4,6 +4,7 @@ from vibecoder.agents.swe import (
     build_swe_agent,
     code_reviewer_analyst,
 )
+from vibecoder.agents.mock_agent import MockAgent
 
 
 def create_agent_by_role(role: str):

--- a/vibecoder/agents/agent.py
+++ b/vibecoder/agents/agent.py
@@ -29,6 +29,15 @@ class BaseAgent(ABC):
         pass
 
     @abstractmethod
+    def set_system_prompt(self, system_prompt: str) -> None:
+        """Set or change the system prompt (role) for the agent.
+
+        This decouples the "role" (system prompt) from the client implementation
+        so callers can swap prompts independently of the underlying client.
+        """
+        pass
+
+    @abstractmethod
     async def ask(self, user_input: str) -> AsyncIterator[AgentMessage]:
         pass
 
@@ -56,6 +65,20 @@ class OpenAIAgent(BaseAgent):
     def set_model(self, model: str):
         """Set a new model for the agent to use."""
         self.model = model
+
+    def set_system_prompt(self, system_prompt: str) -> None:
+        """Replace the system prompt at the start of the conversation.
+
+        The OpenAI agent stores messages as a list where the first message is
+        expected to be the system prompt. Replacing it lets callers change
+        the agent's role without recreating the client.
+        """
+        if not self.messages:
+            self.messages = [{"role": "system", "content": system_prompt}]
+        else:
+            # Ensure the first message is the system prompt
+            self.messages[0] = {"role": "system", "content": system_prompt}
+
 
     async def ask(self, user_input: str) -> AsyncIterator[AgentMessage]:
         self.messages.append({"role": "user", "content": user_input})
@@ -130,7 +153,18 @@ class AnthropicAgent(BaseAgent):
         self.model = model
         self.tools = tools
         self.client = client
+        # Anthropic client expects messages in its own format. Store messages
+        # and the system prompt separately so set_system_prompt can update the
+        # system prompt without recreating the client.
         self.messages = [message.to_anthropic_dict() for message in messages]
+        self.system_prompt = system_prompt
+
+    def set_system_prompt(self, system_prompt: str) -> None:
+        """Set or replace the anthropic system prompt used for future calls.
+
+        Anthropic messages are stored separately; we update the stored
+        system_prompt value so subsequent ask() calls will use it.
+        """
         self.system_prompt = system_prompt
 
     def set_model(self, model: str):

--- a/vibecoder/agents/mock_agent.py
+++ b/vibecoder/agents/mock_agent.py
@@ -14,10 +14,23 @@ class MockAgent(BaseAgent):
         self.tools = tools
         self.model = model
         self.messages = []
+        self.system_prompt = ""
 
     def set_model(self, model: str):
         """Set a new model for the mock agent."""
         self.model = model
+
+    def set_system_prompt(self, system_prompt: str) -> None:
+        """Set or change the mock agent's system prompt (role).
+
+        For the mock agent we store the system prompt and update the first
+        message if present so behavior matches the other agent types.
+        """
+        self.system_prompt = system_prompt
+        if not self.messages:
+            self.messages = [{"role": "system", "content": system_prompt}]
+        else:
+            self.messages[0] = {"role": "system", "content": system_prompt}
 
     async def ask(self, user_input: str) -> AsyncIterator[AgentResponse]:
         self.messages.append({"role": "user", "content": user_input})
@@ -30,7 +43,7 @@ class MockAgent(BaseAgent):
             """Duis -- a multi line message helps us make sure scroll works correctly per line
             aute irure
             dolor in reprehenderit
-            in voluptate 
+            in voluptate
             velit
             esse.""",
             "Cillum dolore eu fugiat nulla pariatur.",


### PR DESCRIPTION
Right now the code couples a role (the system prompt) to an agent instance that also holds the API client. That forces recreating the agent (and its client) every time you want to change role or role behavior, making it harder to:
  - reuse a single client with multiple roles,
  - swap roles quickly in the REPL without reinitializing network clients,
  - test roles in isolation from client configuration.

Proposal: Decouple role (system prompt) from the client by adding a small agent API: `set_system_prompt`

  - Make `set_system_prompt` part of the `BaseAgent` interface.
  - Implement it for `OpenAIAgent`, `AnthropicAgent`, and `MockAgent`

Usage Example:

```python
from openai import AsyncOpenAI
from vibecoder.agents.agent import OpenAIAgent

client = AsyncOpenAI(api_key="OPENAI_API_KEY")
agent = OpenAIAgent(client, system_prompt=<swe_prompt>, tools=...)

# Later switch role without touching the client
agent.set_system_prompt(<analyst_prompt>)
```

Resolve #1 